### PR TITLE
Avoid side effects on stream codecs related to custom queries

### DIFF
--- a/src/main/java/com/sonic2423/neoforwarding/PlayerDataForwarding.java
+++ b/src/main/java/com/sonic2423/neoforwarding/PlayerDataForwarding.java
@@ -77,7 +77,7 @@ public class PlayerDataForwarding {
 
         @Override
         public void write(final FriendlyByteBuf buf) {
-            buf.writeBytes(this.buffer);
+            buf.writeBytes(this.buffer, buf.readerIndex(), buf.readableBytes());
         }
 
         @Override
@@ -90,7 +90,7 @@ public class PlayerDataForwarding {
 
         @Override
         public void write(final FriendlyByteBuf buf) {
-            buf.writeBytes(this.buffer);
+            buf.writeBytes(this.buffer, buf.readerIndex(), buf.readableBytes());
         }
     }
 }


### PR DESCRIPTION
The encoder of a `StreamCodec` should not produce any side effect on the object to encode, which allows encoding multiple times. For example:

```java
MyPacket packet = ...

FriendlyByteBuf buf = new FriendlyByteBuf(Unpooled.buffer());
MyPacket.STREAM_CODEC.encode(buf, packet);
MyPacket.STREAM_CODEC.encode(buf, packet);
MyPacket.STREAM_CODEC.encode(buf, packet);
... // encode packet multiple times
```

The internal data of a packet should not change after multiple encodings while `ClientboundCustomQueryPacket`s and `ServerboundCustomQueryAnswerPacket`s in the current version of NeoForwarding do not fit the situation: the related `write` methods can only be called once because the internal reader indexes of `FriendlyByteBuf`s as members of `PlayerDataForwarding.VelocityPlayerInfoPayload`s and `PlayerDataForwarding.QueryAnswerPayload`s will change.

This pull request fixes this issue by replacing `write` methods with overloads by which side effects will not be produced.